### PR TITLE
Menu tweaks, fixes

### DIFF
--- a/document/2. Server Management.md
+++ b/document/2. Server Management.md
@@ -66,7 +66,7 @@ end
 The A-Shell Terminal is the central administrative tool in Amalgam, offering a secure and structured interface for managing the server. Through the terminal, you can:
 
 * Execute built-in commands for real-time server control
-* Access system logs and debugging utilities  
+* Access system logs and debugging utilities
 * Perform sensitive administrative actions with verified permissions
 
 ### Accesiability
@@ -76,7 +76,7 @@ While primarily intended as an administrative tool, it also supports user-level 
 By default, all players can open the terminal. However, command execution is strictly governed by rank—unless a command is intentionally configured to allow access without rank requirements, in which case it may be used by any player.
 Refer to the section `Adding A-Shell Commands` below for guidance on securely registering and protecting your commands.
 
-To access the terminal, simply press F1.
+To access the terminal, simply press F4.
 
 ## Root-User Initialization
 The Root User role grants the highest level of control within the Amalgam gamebase. It is reserved for the server’s master operator and overrides all other administrative ranks.
@@ -147,5 +147,5 @@ end, "Moderator", {"player", "reason"})
 ```
 * This command can only be executed by users with the **"Moderator"** rank or higher (e.g., Administrator, RootUser)
 * The `{"player", "reason"}` argument list ensures both a valid **target** and **reason** must be provided when executing the command
-*  If any required argument is missing, the terminal will return an automatic error:  
+*  If any required argument is missing, the terminal will return an automatic error:
 > `"[Error] Missing argument: player"` or `"reason"` depending on what was omitted

--- a/gamemode/gui/derma/cl_inventory.lua
+++ b/gamemode/gui/derma/cl_inventory.lua
@@ -41,7 +41,7 @@ function PANEL:Init()
     self.CloseButton.DoClick = function()
         self:CloseInventory()
     end
-    
+
     self.CloseButton.Paint = function(s, w, h)
         local col = s:IsHovered() and Color(255, 168, 35, 180) or Color(150, 75, 25, 180)
         draw.RoundedBox(8, 0, 0, w, h, col)
@@ -140,7 +140,7 @@ function PANEL:ToolTip(itemData)
     icon:SetPos(0, 0)
     icon:SetTooltip(false)
     icon:SetMouseInputEnabled(false)
-    icon.PaintOver = function() end 
+    icon.PaintOver = function() end
 
     local nameLabel = vgui.Create("DLabel", tooltip)
     nameLabel:SetFont("Amalgam.ToolTipLabelBig")
@@ -275,12 +275,10 @@ function PANEL:PopulateInventory()
             end
 
             container.OnCursorExited = function()
-                timer.Simple(0.05, function()
-                    local hovered = vgui.GetHoveredPanel()
-                    if IsValid(self.Tooltip) and (not hovered or hovered:GetName() ~= "DMenu") then
-                        self.Tooltip:Remove()
-                    end
-                end)
+                local hovered = vgui.GetHoveredPanel()
+                if IsValid(self.Tooltip) and (not hovered or hovered:GetName() ~= "DMenu") then
+                    self.Tooltip:Remove()
+                end
             end
 
             if amount > 1 then
@@ -312,7 +310,7 @@ function PANEL:PopulateInventory()
                                 if IsValid(self.Tooltip) then
                                     self.Tooltip:Remove()
                                 end
-                                timer.Simple(0.1, function() 
+                                timer.Simple(0.1, function()
                                     self:PopulateInventory()
                                     if (IsValid(self.WeightLabel)) then
                                         local weight = LocalPlayer():GetInventoryWeight()
@@ -323,7 +321,7 @@ function PANEL:PopulateInventory()
                             end)
                         end
                     end
-                    
+
                     menu.OnRemove = function()
                         if IsValid(self.Tooltip) then
                             self.Tooltip:Remove()
@@ -334,6 +332,12 @@ function PANEL:PopulateInventory()
                 end
             end
         end
+    end
+end
+
+function PANEL:OnKeyCodePressed(key)
+    if input.LookupKeyBinding(key) == "+menu" then
+        self:CloseInventory()
     end
 end
 

--- a/gamemode/gui/derma/cl_scoreboard.lua
+++ b/gamemode/gui/derma/cl_scoreboard.lua
@@ -1,5 +1,11 @@
 local PANEL = {}
 
+local gradient_down = Material("vgui/gradient-d")
+local gradient_right = Material("vgui/gradient-l")
+
+local color_dark = Color(15, 15, 15, 230)
+local color_orange = Color(255, 168, 0, 245)
+
 function PANEL:Init()
     self:SetSize(ScrW() * 0.35, ScrH() * 0.6)
     self:Center()
@@ -26,47 +32,61 @@ function PANEL:Paint(w, h)
     surface.SetDrawColor(glowColor.r, glowColor.g, glowColor.b, 200)
     surface.DrawOutlinedRect(-2, -2, w + 4, h + 4, 3)
 
-    draw.RoundedBox(8, 0, 0, w, h, Color(15, 15, 15, 230))
+    draw.RoundedBox(8, 0, 0, w, h, color_dark)
 
-    local gradient = Material("vgui/gradient-d")
     surface.SetDrawColor(15, 15, 15, 25)
-    surface.SetMaterial(gradient)
+    surface.SetMaterial(gradient_down)
     surface.DrawTexturedRect(0, 0, w, h)
 
     local titleColor = HSVToColor(30 + math.sin(CurTime() * 2) * 10, 1, 1)
     draw.SimpleText("Player List", "Amalgam.HudLabelSmall", w / 2, 15, titleColor, TEXT_ALIGN_CENTER)
 end
 
+local copied = 0
 function PANEL:RefreshList()
     self.PlayerList:Clear()
 
-    for _, ply in ipairs(player.GetAll()) do
+    for i, ply in ipairs(player.GetAll()) do
         local plyPanel = self.PlayerList:Add("DButton")
         plyPanel:SetSize(self:GetWide(), 70)
         plyPanel:Dock(TOP)
-        plyPanel:DockMargin(0, 0, 0, 5)
+        plyPanel:DockMargin(1, 0, 1, 5)
         plyPanel:SetText("")
+        plyPanel.CopyAlpha = 0
 
+        local me = (ply == LocalPlayer())
+        local rank = ply.GetRank and ply:GetRank() or "User"
         function plyPanel:Paint(w, h)
             surface.SetDrawColor(30, 30, 30, 200)
             surface.DrawRect(0, 0, w, h)
 
-            local gradient = Material("vgui/gradient-d")
             surface.SetDrawColor(35, 35, 35, 120)
-            surface.SetMaterial(gradient)
+            surface.SetMaterial(gradient_down)
             surface.DrawTexturedRect(0, 0, w, h)
 
-            local rank = ply.GetRank and ply:GetRank() or "User"
+            if me then
+                surface.SetDrawColor(89, 89, 89, 40)
+                surface.SetMaterial(gradient_right)
+                surface.DrawTexturedRect(0, 0, w, h)
+            end
+
             local pingColor = HSVToColor(30 + math.sin(CurTime() * 2) * 10, 1, 1)
 
-            draw.SimpleText(ply:Nick(), "Amalgam.HudLabelSmall", 70, 10, Color(255, 255, 255), TEXT_ALIGN_LEFT)
-            draw.SimpleText(rank, "Amalgam.HudLabelTiny", 70, 35, Color(255, 168, 0, 245), TEXT_ALIGN_LEFT)
+            draw.SimpleText(ply:Nick(), "Amalgam.HudLabelSmall", 70, 10, color_white, TEXT_ALIGN_LEFT)
+            draw.SimpleText(rank, "Amalgam.HudLabelTiny", 70, 35, color_orange, TEXT_ALIGN_LEFT)
             draw.SimpleText(ply:Ping(), "Amalgam.HudLabelTiny", w - 15, 25, pingColor, TEXT_ALIGN_RIGHT)
+
+            if plyPanel.CopyAlpha > 0 and copied == i then
+                draw.SimpleText( "SteamID copied.", "Amalgam.HudLabelTiny", w / 2, h / 2, ColorAlpha(color_white, plyPanel.CopyAlpha), TEXT_ALIGN_CENTER, TEXT_ALIGN_CENTER )
+                plyPanel.CopyAlpha = plyPanel.CopyAlpha - ( FrameTime() * 200 )
+            end
         end
 
         plyPanel.DoClick = function()
             SetClipboardText(ply:SteamID())
             surface.PlaySound("buttons/button14.wav")
+            plyPanel.CopyAlpha = 255
+            copied = i
         end
 
         -- Avatar Image

--- a/gamemode/modules/chatbox/derma/cl_chat.lua
+++ b/gamemode/modules/chatbox/derma/cl_chat.lua
@@ -59,7 +59,7 @@ function PANEL:Init()
                 net.WriteString(text)
             net.SendToServer()
 
-            local formatLog = "[".. string.upper(self.chatPrefix) .."][".. LocalPlayer():Nick() .. "] " .. LocalPlayer():GetCharNickname() .. ": " .. text 
+            local formatLog = "[".. string.upper(self.chatPrefix) .."][".. LocalPlayer():Nick() .. "] " .. LocalPlayer():GetCharNickname() .. ": " .. text
 
             net.Start("nSendChatLog")
                 net.WriteString(formatLog)
@@ -110,14 +110,14 @@ function PANEL:OpenChatbox()
     self.Input:RequestFocus()
     Amalgam.ChatOpen = true
     LocalPlayer():SetTyping(true)
-  
+
     net.Start("nTypingStatus")
         net.WriteBool(true)
     net.SendToServer()
 end
 
 function PANEL:CloseChatbox()
-    self:SetVisible(false)
+    self:Remove()
     Amalgam.ChatOpen = false
     net.Start("nTypingStatus")
     	net.WriteBool(false)

--- a/gamemode/modules/chatbox/sh_module.lua
+++ b/gamemode/modules/chatbox/sh_module.lua
@@ -91,15 +91,15 @@ Amalgam:RegisterChatType("pm", {
     Private = true,
     Format = function(ply, msg)
         local name, content = msg:match("^(%S+)%s+(.+)$")
-        if (not name or not content) then 
+        if (not name or not content) then
             ply:Notify("Invalid Name Given!")
-            return true 
+            return true
         end
 
         local target = ply:FindPlayer(name)
         if (not IsValid(target)) then
             ply:Notify("No target found by: " .. name .. ".")
-            return true 
+            return true
         end
 
         Amalgam.SendFormattedMessage({ply, target}, {
@@ -204,9 +204,16 @@ if (CLIENT) then
         end
     end)
 
+    function MODULE:OnPauseMenuShow()
+        if Amalgam.ChatOpen then
+            Amalgam.Chatbox:CloseChatbox()
+            return false
+        end
+    end
+
     function MODULE:HUDShouldDraw(element)
-        if (element == "CHudChat")then 
-            return false 
+        if (element == "CHudChat")then
+            return false
         end
     end
 
@@ -285,8 +292,8 @@ if (CLIENT) then
 	    if (not pressed) then return end
 
 	    if (pressed and bind == "messagemode") then
-	        if (IsValid(Amalgam.Chatbox)) then 
-	            Amalgam.Chatbox:Remove() 
+	        if (IsValid(Amalgam.Chatbox)) then
+	            Amalgam.Chatbox:Remove()
 	        end
 	        Amalgam.Chatbox = vgui.Create("AmalgamChatBox")
 	        Amalgam.Chatbox:OpenChatbox()
@@ -303,4 +310,4 @@ end
 
 function meta:IsTyping()
     return self:GetNWBool("PlayerTyping", false)
-end 
+end


### PR DESCRIPTION
Inventory
---
- Close the menu using the same open key

Chatbox
---
- Close the menu with escape key
- Fixed not being able to open the main menu after sending an empty message

Scoreboard
---
- Indicator when a Steam ID is copied
- Edit margins to not overlap border
- Create colors/materials only once, instead of every frame
- Highlight the local player

Docs
---
- Correct the key for opening the admin CLI